### PR TITLE
Meals index endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,58 @@ Failed deletion response (did not find a food with that id):
 Status: 404
 ```
 
+### List all meals in the database (along with their associated foods)
+Request:
+```
+GET /api/v1/meals
+Accept: application/json
+```
+Example response:
+```
+Status: 200
+Content-Type: application/json
+Body:
+[
+    {
+        "id": 1,
+        "name": "Breakfast",
+        "foods": [
+            {
+                "id": 1,
+                "name": "Banana",
+                "calories": 150
+            },
+            {
+                "id": 6,
+                "name": "Yogurt",
+                "calories": 550
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "name": "Snack",
+        "foods": [
+            {
+                "id": 1,
+                "name": "Banana",
+                "calories": 150
+            },
+            {
+                "id": 9,
+                "name": "Gum",
+                "calories": 50
+            }
+        ]
+    },
+    {
+        "id": 3,
+        "name": "Lunch",
+        "foods": []
+    }
+]
+```
+
 ## Core Contributors
  - Alexandra Chakeres, [@chakeresa](https://github.com/chakeresa)
  - Ryan Miller, [@ryanmillergm](https://github.com/ryanmillergm)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ View the project board at https://github.com/ryanmillergm/quantified_self/projec
  - Run server using latest file updates: nodemon
  - Run shell commands: shelljs
  - Make HTTP requests in tests: supertest
+ - Model validation: joi
 
 ## Local Setup
  - `$ git clone git@github.com:ryanmillergm/quantified_self.git`

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var logger = require('morgan');
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
 var apiFoodsRouter = require('./routes/api/v1/foods');
+var apiMealsRouter = require('./routes/api/v1/meals');
 
 var app = express();
 
@@ -19,5 +20,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 app.use('/api/v1/foods', apiFoodsRouter);
+app.use('/api/v1/meals', apiMealsRouter);
 
 module.exports = app;

--- a/migrations/20190823001534-create-meal.js
+++ b/migrations/20190823001534-create-meal.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Meals', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Meals');
+  }
+};

--- a/migrations/20190823002328-create-meal-food.js
+++ b/migrations/20190823002328-create-meal-food.js
@@ -1,0 +1,51 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('MealFoods', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      MealId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Meals',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      FoodId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Food',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    }).then(() => {
+      let sql = `CREATE UNIQUE INDEX "MealFoodCompoundIndex"
+              ON "MealFoods"
+              USING btree
+              ("MealId", "FoodId");
+            `;
+      return queryInterface.sequelize.query(sql, { raw: true });
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('MealFoods');
+  }
+};

--- a/models/food.js
+++ b/models/food.js
@@ -5,7 +5,12 @@ module.exports = (sequelize, DataTypes) => {
     calories: DataTypes.INTEGER
   }, {});
   Food.associate = function(models) {
-    // associations can be defined here
+    Food.belongsToMany(models.Meal, {
+      through: "MealFoods",
+      as: "foods",
+      foreignKey: "FoodId",
+      otherKey: "MealId"
+    });
   };
   return Food;
 };

--- a/models/meal.js
+++ b/models/meal.js
@@ -4,7 +4,12 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING
   }, {});
   Meal.associate = function(models) {
-    // associations can be defined here
+    Meal.belongsToMany(models.Food, {
+      through: 'MealFoods',
+      as: 'foods',
+      foreignKey: 'MealId',
+      otherKey: 'FoodId'
+    })
   };
   return Meal;
 };

--- a/models/meal.js
+++ b/models/meal.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Meal = sequelize.define('Meal', {
+    name: DataTypes.STRING
+  }, {});
+  Meal.associate = function(models) {
+    // associations can be defined here
+  };
+  return Meal;
+};

--- a/models/mealfood.js
+++ b/models/mealfood.js
@@ -1,0 +1,11 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const MealFood = sequelize.define('MealFood', {
+    MealId: DataTypes.INTEGER,
+    FoodId: DataTypes.INTEGER
+  }, {});
+  MealFood.associate = function(models) {
+    // associations can be defined here
+  };
+  return MealFood;
+};

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -6,14 +6,7 @@ var Food = require("../../../models").Food;
 
 /*GET all meals*/
 router.get("/", function(req, res, next) {
-  return Meal.findAll({ include: 'foods'
-    // attributes: ["id", "name", "foods", "id", "name", "calories"],
-    // include: [{
-    //     model: Food,
-    //     as: 'foods',
-    //     attributes: ["id", "name", "calories"]
-    // }]
-  })
+  return Meal.findAll({ include: 'foods'})
   .then(meals => {
     res.setHeader("Content-Type", "application/json");
     res

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -2,22 +2,24 @@
 var express = require("express");
 var router = express.Router();
 var Meal = require("../../../models").Meal;
+var Food = require("../../../models").Food;
 
 /*GET all meals*/
 router.get("/", function(req, res, next) {
   return Meal.findAll({
-    attributes: ["id", "name", "calories"],
-    include: [
-      {
-        model: Foods
-      }
-    ]
+    attributes: ["id", "name"],
+    include: [{
+        model: Food,
+        as: 'foods'
+    }]
   })
-    .then(meals => {
-      res.setHeader("Content-Type", "application/json");
-      res.status(200).send(JSON.stringify(meals));
-    })
-    .catch(err => {
-      res.status(500).send(JSON.stringify({ error: err }));
-    });
+  .then(meals => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).send(JSON.stringify(meals));
+  })
+  .catch(err => {
+    res.status(500).send(JSON.stringify({ error: err }));
+  });
 });
+
+module.exports = router;

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -1,0 +1,23 @@
+// const Joi = require("@hapi/joi");
+var express = require("express");
+var router = express.Router();
+var Meal = require("../../../models").Meal;
+
+/*GET all meals*/
+router.get("/", function(req, res, next) {
+  return Meal.findAll({
+    attributes: ["id", "name", "calories"],
+    include: [
+      {
+        model: Foods
+      }
+    ]
+  })
+    .then(meals => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(200).send(JSON.stringify(meals));
+    })
+    .catch(err => {
+      res.status(500).send(JSON.stringify({ error: err }));
+    });
+});

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -6,18 +6,27 @@ var Food = require("../../../models").Food;
 
 /*GET all meals*/
 router.get("/", function(req, res, next) {
-  return Meal.findAll({
-    attributes: ["id", "name"],
-    include: [{
-        model: Food,
-        as: 'foods'
-    }]
+  return Meal.findAll({ include: 'foods'
+    // attributes: ["id", "name", "foods", "id", "name", "calories"],
+    // include: [{
+    //     model: Food,
+    //     as: 'foods',
+    //     attributes: ["id", "name", "calories"]
+    // }]
   })
   .then(meals => {
+    // console.log("first meal =")
+    // console.log(meals[0])
     res.setHeader("Content-Type", "application/json");
-    res.status(200).send(JSON.stringify(meals));
+    res
+      .status(200)
+      .send(
+        JSON.stringify(meals, ["id", "name", "foods", "id", "name", "calories"])
+      );
   })
   .catch(err => {
+    console.log('error =')
+    console.log(err)
     res.status(500).send(JSON.stringify({ error: err }));
   });
 });

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -15,8 +15,6 @@ router.get("/", function(req, res, next) {
     // }]
   })
   .then(meals => {
-    // console.log("first meal =")
-    // console.log(meals[0])
     res.setHeader("Content-Type", "application/json");
     res
       .status(200)
@@ -25,8 +23,6 @@ router.get("/", function(req, res, next) {
       );
   })
   .catch(err => {
-    console.log('error =')
-    console.log(err)
     res.status(500).send(JSON.stringify({ error: err }));
   });
 });

--- a/test/requests/meals/index.test.js
+++ b/test/requests/meals/index.test.js
@@ -3,6 +3,7 @@ var request = require("supertest");
 var expect = require('chai').expect;
 var Food = require('../../../models').Food;
 var Meal = require('../../../models').Meal;
+var MealFood = require('../../../models').MealFood;
 
 describe('api v1 meals GET', function () {
   describe('user can get all meals in database', function () {
@@ -19,7 +20,7 @@ describe('api v1 meals GET', function () {
           name: "candy"
         }
       ]).then(() => {
-        return Meal.bulkcreate([
+        return Meal.bulkCreate([
           {
             id: 1,
             name: "breakfast"
@@ -30,7 +31,7 @@ describe('api v1 meals GET', function () {
           }
         ])
       }).then(() => {
-        return MealFood.bulkcreate([
+        return MealFood.bulkCreate([
           {
             FoodId: 1,
             MealId: 1
@@ -70,7 +71,7 @@ describe('api v1 meals GET', function () {
     });
 
     it('returns 200 if no foods', (done) => {
-      Meal.bulkcreate([
+      Meal.bulkCreate([
         {
           name: "breakfast"
         },

--- a/test/requests/meals/index.test.js
+++ b/test/requests/meals/index.test.js
@@ -1,0 +1,108 @@
+var app = require('../../../app');
+var request = require("supertest");
+var expect = require('chai').expect;
+var Food = require('../../../models').Food;
+var Meal = require('../../../models').Meal;
+
+describe('api v1 meals GET', function () {
+  describe('user can get all meals in database', function () {
+    it('returns JSON with id name and the associated foods', (done) => {
+      Food.bulkCreate([
+        {
+          id: 1,
+          calories: "10",
+          name: "peas"
+        },
+        {
+          id: 2,
+          calories: "300",
+          name: "candy"
+        }
+      ]).then(() => {
+        return Meal.bulkcreate([
+          {
+            id: 1,
+            name: "breakfast"
+          },
+          {
+            id: 2,
+            name: "lunch"
+          }
+        ])
+      }).then(() => {
+        return MealFood.bulkcreate([
+          {
+            FoodId: 1,
+            MealId: 1
+          },
+          {
+            FoodId: 2,
+            MealId: 1
+          },
+          {
+            FoodId: 1,
+            MealId: 2
+          }
+        ])
+      }).then(() => {
+        return request(app)
+          .get('/api/v1/meals')
+      }).then(response => {
+        expect(response.statusCode).to.equal(200);
+
+        expect(response.body).to.have.lengthOf(2);
+
+        let firstMeal = response.body[0];
+        expect(firstMeal).to.include.all.keys('id', 'name', 'foods');
+        expect(firstMeal).to.not.include.key('createdAt');
+        expect(firstMeal).to.not.include.key('updatedAt');
+        
+        expect(firstMeal.name).to.equal('breakfast');
+        expect(firstMeal.foods).to.have.lengthOf(2);
+        
+        let firstFood = firstMeal.foods[0];
+        expect(firstFood).to.include.all.keys('id', 'name', 'calories')
+        expect(firstFood).to.not.include.key('createdAt');
+        expect(firstFood).to.not.include.key('updatedAt');
+
+        done();
+      })
+    });
+
+    it('returns 200 if no foods', (done) => {
+      Meal.bulkcreate([
+        {
+          name: "breakfast"
+        },
+        {
+          name: "lunch"
+        }
+      ]).then(() => {
+          request(app)
+            .get('/api/v1/meals')
+            .then(response => {
+              expect(response.statusCode).to.equal(200);
+    
+              expect(response.body).to.have.lengthOf(2);
+
+              let firstMeal = response.body[0];
+              expect(firstMeal.foods).to.equal([]);
+
+              done();
+            })
+      })
+    });
+
+    it('returns 200 if no results', (done) => {
+      request(app)
+        .get('/api/v1/meals')
+        .then(response => {
+          expect(response.statusCode).to.equal(200);
+
+          expect(response.body).to.have.lengthOf(0);
+
+          done();
+        })
+    });
+  });
+});

--- a/test/requests/meals/index.test.js
+++ b/test/requests/meals/index.test.js
@@ -87,7 +87,7 @@ describe('api v1 meals GET', function () {
               expect(response.body).to.have.lengthOf(2);
 
               let firstMeal = response.body[0];
-              expect(firstMeal.foods).to.equal([]);
+              expect(firstMeal.foods).to.deep.equal([]);
 
               done();
             })

--- a/test/specHelper.js
+++ b/test/specHelper.js
@@ -1,4 +1,6 @@
 var Food = require('../models').Food;
+var Meal = require('../models').Meal;
+var MealFood = require('../models').MealFood;
 var shell = require('shelljs');
 
 before(function() {
@@ -15,8 +17,12 @@ before(function() {
 beforeEach(async function() {
   console.log("global beforeEach hook starting...")
   this.timeout(20000);
+  console.log("destroying all MealFoods...")
+  await MealFood.destroy({ where: {} })
   console.log("destroying all foods...")
   await Food.destroy({ where: {} })
+  console.log("destroying all meals...")
+  await Meal.destroy({ where: {} })
 });
 
 // after(function() {


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Add `GET /api/v1/meals` endpoint that lists all meals in the database, along with the associated foods (resolves #6)
 - Add `mealsRouter`
 - Add `Meal` and `MealFood` models/tables. A meal belongsToMany foods and a food belongsToMany meals.
 - Update `beforeEach` for testing to destroy all `Meal`s and `MealFood`s
 
**The following checks have been completed:**
 - [x] Tested new feature(s) as well as any feasible edge cases
 - [x] Updated README for changes (new endpoints, new packages, etc)
 - [x] Merged in the latest master & resolved all merge conflicts
 - [x] Ran database migrations
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman
 