### PR TITLE
Exclude migrations coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
 var apiFoodsRouter = require('./routes/api/v1/foods');
 var apiMealsRouter = require('./routes/api/v1/meals');
 
@@ -18,7 +17,6 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
 app.use('/api/v1/foods', apiFoodsRouter);
 app.use('/api/v1/meals', apiMealsRouter);
 

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "nyc": "^14.1.1",
     "shelljs": "^0.8.3",
     "supertest": "^4.0.2"
+  },
+  "nyc": {
+    "exclude": [
+      "**/*.test.js",
+      "**/migrations/**"
+    ]
   }
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Excludes db migration files from test coverage
 - Removes the `usersRouter` (unused)
 
**The following checks have been completed:**
 - [N/A] Tested new feature(s) as well as any feasible edge cases
 - [N/A] Updated README for changes (new endpoints, new packages, etc)
 - [x] Merged in the latest master & resolved all merge conflicts
 - [N/A] Ran database migrations
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [N/A] Checked affected endpoints in Postman